### PR TITLE
Fix crash due to non-existent realistic version of biomes

### DIFF
--- a/src/main/java/rtg/world/biome/WorldChunkManagerRTG.java
+++ b/src/main/java/rtg/world/biome/WorldChunkManagerRTG.java
@@ -155,7 +155,11 @@ public class WorldChunkManagerRTG extends WorldChunkManager implements RTGBiomeP
         int[] aint = this.genBiomes.getInts(par2, par3, par4, par5);
 
         for (int i1 = 0; i1 < par4 * par5; ++i1) {
-            par1ArrayOfBiomeGenBase[i1] = RealisticBiomeBase.getBiome(aint[i1]).baseBiome;
+            try {
+                par1ArrayOfBiomeGenBase[i1] = RealisticBiomeBase.getBiome(aint[i1]).baseBiome;
+            } catch (Exception e) {
+                par1ArrayOfBiomeGenBase[i1] = biomePatcher.getPatchedBaseBiome("Missing biome " + aint[i1]);
+            }
         }
 
         return par1ArrayOfBiomeGenBase;


### PR DESCRIPTION
See https://github.com/kotmatross28729/UltimateCavesMod/issues/3 (https://github.com/kotmatross28729/UltimateCavesMod/issues/3#issuecomment-2888918125)

RTG already has a protection mechanism in the form of biomePatcher for such cases, but for some reason it is not used in the `RealisticBiomeBase.getBiomesForGeneration`.

Basically, if (maybe due to some weird combination of mods) RTG tries to find a realistic version of a biome and doesn't find one - it will crash.

In the case mentioned above, the problematic biome was "Dry River" from BOP.

All this does is replace the problematic biome with plains (or another biome specified in the config).

Tested - works, no side effects/generation bugs.

